### PR TITLE
Strip debug info to reduce file size

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,6 +19,7 @@ jobs:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         goarch: amd64
         goos: linux
+        ldflags: "-s -w"
   release-darwin-amd64:
     name: release darwin/amd64
     runs-on: ubuntu-latest
@@ -34,3 +35,5 @@ jobs:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         goarch: amd64
         goos: darwin
+        ldflags: "-s -w"
+


### PR DESCRIPTION
~20% size reduction.

```
$ go build .
$ ls -al logrecycler
-rwxr-xr-x 1 oatamanenko 11807996 Jun  3 11:05 logrecycler
$ make
go build -ldflags="-s -w" .
$ ls -al logrecycler
-rwxr-xr-x 1 oatamanenko 9424124 Jun  3 11:05 logrecycler
```