### PR TITLE
subcommand

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,7 +1,7 @@
 # Logrecycler [![Build Status](https://travis-ci.org/grosser/logrecycler.svg)](https://travis-ci.org/grosser/logrecycler) [![coverage](https://img.shields.io/badge/coverage-100%25-success.svg)](https://github.com/grosser/go-testcov) [![Build](https://github.com/grosser/logrecycler/workflows/Build/badge.svg)](https://github.com/grosser/logrecycler/releases)
 
 Re-process logs from applications you cannot modify to:
-- convert plaintext or glog logs from stdin to json on stdout
+- convert plaintext or glog logs from stdin (or command) to json on stdout
 - remove noise
 - add log levels / timestamp / details / captured values
 - emit prometheus metric
@@ -21,7 +21,7 @@ stdout: {"ts":"2020-05-30 10:13:00","level":"error","message":"error connecting 
 
 ## Install
 
-Download [latest binary](https://github.com/grosser/logrecycler/releases):
+Download the [latest binary](https://github.com/grosser/logrecycler/releases):
 
 ```
 curl -sfL <PICK URL FROM RELEASES PAGE> | tar -zx && chmod +x logrecycler && ./logrecycler --version
@@ -92,6 +92,12 @@ Pipe your logs to the recycler:
 
 ```
 set -o pipefail; <your-program-here> | logrecycler
+```
+
+or make the recycler call your command:
+
+```
+logrecycler -- <your-program-here>
 ```
 
 # Development

--- a/main_test.go
+++ b/main_test.go
@@ -113,6 +113,12 @@ var _ = Describe("main", func() {
 		})
 	})
 
+	It("can call command", func() {
+		withConfig("", func() {
+			Expect(parseCommand("hi\"foo")).To(Equal(`{"message":"hi\"foo"}`))
+		})
+	})
+
 	Context("Glog", func() {
 		It("parses simple", func() {
 			withConfig("---\nglog: simple", func() {
@@ -301,6 +307,15 @@ func parse(input string) (output string) {
 		output = captureStdout(func() { main() })
 		output = strings.TrimRight(output, "\n")
 	})
+	return
+}
+
+func parseCommand(input string) (output string) {
+	before := os.Args
+	os.Args = []string{"foo", "--", "echo", input}
+	defer func() { os.Args = before }()
+	output = captureStdout(func() { main() })
+	output = strings.TrimRight(output, "\n")
 	return
 }
 

--- a/test.rb
+++ b/test.rb
@@ -112,6 +112,13 @@ describe "logrecycler" do
       end
     end
 
+    it "stops when command is killed" do
+      with_config "" do
+        Thread.new { sleep standard_boot_time; sh("pkill -f '^sleep 999'") }
+        call("-- sleep 999", pipe: nil, expected_exit: 255).must_equal ""
+      end
+    end
+
     it "does not leave command running when getting signaled" do
       time = 5
       check_ps = ->(size) do

--- a/utils.go
+++ b/utils.go
@@ -1,9 +1,14 @@
 package main
 
 import (
+	"bufio"
 	"fmt"
+	"io"
 	"os"
+	"os/exec"
+	"os/signal"
 	"regexp"
+	"syscall"
 )
 
 // https://www.golangprograms.com/remove-duplicate-values-from-slice.html
@@ -30,6 +35,16 @@ func removeElement(haystack []string, needle string) []string {
 	return clean
 }
 
+// split an array of strings when a given delimiter is found
+func splitArrayOn(arr []string, delimiter string) ([]string, []string) {
+	for i, item := range arr {
+		if item == delimiter {
+			return arr[0:i], arr[i+1:]
+		}
+	}
+	return arr, nil
+}
+
 // https://stackoverflow.com/questions/21362950/getting-a-slice-of-keys-from-a-map
 func keys(mymap map[string]string) []string {
 	keys := make([]string, 0, len(mymap))
@@ -49,7 +64,7 @@ func helpfulMustCompile(expr string, location string) *regexp.Regexp {
 	compiled, err := regexp.Compile(expr)
 	if err != nil {
 		// untested section
-		fmt.Fprintf(os.Stderr, "Error: regular expression from "+location+": "+err.Error())
+		_, _ = fmt.Fprintf(os.Stderr, "Error: regular expression from "+location+": "+err.Error())
 		os.Exit(1)
 	}
 	return compiled
@@ -64,7 +79,76 @@ func addCaptureNames(re *regexp.Regexp, labels *[]string) {
 }
 
 // https://stackoverflow.com/questions/39993688/are-golang-slices-passed-by-value
-func pipingToStding() bool {
+func isPipingToStdin() bool {
 	stat, _ := os.Stdin.Stat()
 	return (stat.Mode() & os.ModeCharDevice) == 0
+}
+
+// ReaderChannel is an io.Reader used to stream command output to the log processor
+type ReaderChannel struct {
+	channel chan ([]byte)
+}
+
+func (b ReaderChannel) Read(p []byte) (n int, err error) {
+	msg, open := <-b.channel
+	if open {
+		copy(p, msg)
+		return len(msg), nil
+	} else {
+		return 0, io.EOF
+	}
+}
+
+// executeCommand executes a shell command and returns a reader from the combined stdout and stderr + exit code channel
+func executeCommand(command []string) (io.Reader, chan (int), error) {
+	cmd := exec.Command(command[0], command[1:]...)
+	exit := make(chan int)
+	output := ReaderChannel{make(chan []byte)}
+
+	// Send all output into a pipe
+	pipeReader, pipeWriter, err := os.Pipe()
+	if err != nil {
+		// untested section
+		return nil, nil, err
+	}
+	cmd.Stdout = pipeWriter
+	cmd.Stderr = pipeWriter
+
+	// Start the command
+	err = cmd.Start()
+	if err != nil {
+		// untested section
+		return nil, nil, err
+	}
+
+	// Pass on any signal, so the logrecycler behaves like the command it wraps
+	signalChannel := make(chan os.Signal, 1)
+	signal.Notify(signalChannel, os.Interrupt, syscall.SIGTERM, syscall.SIGQUIT, syscall.SIGUSR1, syscall.SIGUSR2, syscall.SIGHUP)
+	go func() {
+		s, open := <-signalChannel
+		if open {
+			// untested section
+			_ = cmd.Process.Signal(s)
+		}
+	}()
+
+	// Stream the output to the buffer, to be consumed by the log parser
+	go func() {
+		scanner := bufio.NewScanner(pipeReader)
+		for scanner.Scan() {
+			output.channel <- append(scanner.Bytes(), '\n')
+		}
+		close(output.channel)
+	}()
+
+	// Wait for the command to finish and store the exit code
+	go func() {
+		_ = cmd.Wait()
+		_ = pipeReader.Close() // make scanner stop
+		_ = pipeWriter.Close()
+		close(signalChannel) // make sure exiting the program does not re-signal ourselves
+		exit <- cmd.ProcessState.ExitCode()
+	}()
+
+	return output, exit, nil
 }


### PR DESCRIPTION
- makes `from scratch` easier
- sends signals to sub-process
- captures stdout and stderr (possibly controversial)
- exits with exit-stats from sub-process