### PR TITLE
omit symbol table and debug information from release binary

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,10 +16,11 @@ jobs:
     - name: add version
       run: sed -i s/"master"/"${GITHUB_REF##*/}"/ main.go
     - name: compile and release
-      uses: wangyoucao577/go-release-action@v1.38
+      uses: wangyoucao577/go-release-action@v1.40
       env:
         CGO_ENABLED: "0" # support alpine
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         goarch: ${{ matrix.arch }}
         goos:  ${{ matrix.os }}
+        ldflags: "-s -w"


### PR DESCRIPTION
Flag -s omits the symbol table and debug information
and -w strips the DWARF symbol table from the resulting binary


- pros: slightly smaller binary
- cons: users may want the debug info