### PR TITLE
allow multiple message to buffer to not block main process

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -21,10 +21,22 @@ stdout: {"ts":"2020-05-30 10:13:00","level":"error","message":"error connecting 
 
 ## Install
 
+### Option 1: Download
+
 Download the [latest binary](https://github.com/grosser/logrecycler/releases):
 
 ```
 curl -sfL <PICK URL FROM RELEASES PAGE> | tar -zx && chmod +x logrecycler && ./logrecycler --version
+```
+
+### Option 2: Build from source
+
+```
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends git make golang && \
+    rm -rf /var/lib/apt/lists/* && \
+    git clone https://github.com/grosser/logrecycler.git logrecycler --quiet --depth=1 --branch grosser/native && \
+    cd logrecycler && make && ./logrecycler --version
 ```
 
 ## Configure

--- a/utils.go
+++ b/utils.go
@@ -103,7 +103,7 @@ func (b ReaderChannel) Read(p []byte) (n int, err error) {
 func executeCommand(command []string) (io.Reader, chan (int), error) {
 	cmd := exec.Command(command[0], command[1:]...)
 	exit := make(chan int)
-	output := ReaderChannel{make(chan []byte)}
+	output := ReaderChannel{make(chan []byte, 100)}
 
 	// Send all output into a pipe
 	pipeReader, pipeWriter, err := os.Pipe()


### PR DESCRIPTION
saw main process hanging when it was executed by logrecycler ... no idea why really,
but a buffer could help make things faster (by blocking less) and maybe solve the issue at the same time

tried with log messages at [all places were things could block](https://github.com/grosser/logrecycler/pull/28) and nothing came up after this change 🤞 